### PR TITLE
setup separate tokens pkg for core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3552,6 +3552,10 @@
       "resolved": "packages/core-knapsack",
       "link": true
     },
+    "node_modules/@my-org/core-tokens": {
+      "resolved": "packages/core-tokens",
+      "link": true
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -18316,6 +18320,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@my-org/core-tokens": "^1.0.0",
         "react": "^18.2.0"
       },
       "devDependencies": {
@@ -18335,6 +18340,13 @@
         "@types/react": "^18.2.37",
         "react": "^18.2.0",
         "typescript": "^5.2.2"
+      }
+    },
+    "packages/core-tokens": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@knapsack/app": "^4.34.0"
       }
     },
     "packages/ds-react": {

--- a/packages/core-knapsack/knapsack.config.js
+++ b/packages/core-knapsack/knapsack.config.js
@@ -17,6 +17,9 @@ module.exports = configureKnapsack({
       },
     }),
   ],
+  designTokens: {
+    distDir: join(__dirname, '../core-tokens/dist'),
+  },
   plugins: [],
   cloud: {
     siteId: "ks-example-ds-1-systems-core",

--- a/packages/core-tokens/package.json
+++ b/packages/core-tokens/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@my-org/core-tokens",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/design-tokens.cjs",
+  "module": "dist/design-tokens.js",
+  "types": "dist/design-tokens.d.ts",
+  "scripts": {
+    "build": "knapsack --config ../core-knapsack/knapsack.config.js build:tokens"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@knapsack/app": "^4.34.0"
+  },
+  "author": "KnapsackBot 53622700+KnapsackBot@users.noreply.github.com",
+  "license": "ISC"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
     "start": "run-p watch:js watch:css"
   },
   "dependencies": {
+    "@my-org/core-tokens": "^1.0.0",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/core/tailwind.config.js
+++ b/packages/core/tailwind.config.js
@@ -1,3 +1,5 @@
+const tokens = require('@my-org/core-tokens/dist/design-tokens.nested.json')
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.tsx'],


### PR DESCRIPTION
- makes a new package: `@my-org/core-tokens`
- does not set up brand 1 or 2
- build process can now go:
1. core-tokens
2. core
3. core-knapsack 
